### PR TITLE
Output a warning if the input file is too large

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Easy and secure paper backups of (smallish) secrets using the Age format ([age-e
 
 ## Limitations
 
-* The maximum input size is about 1.5 KiB as QR codes cannot encode arbitrarily large payloads (1.5 KiB plaintext results in a payload of about 3 KiB when encrypted)
+* The maximum input size is about 1.9 KiB as QR codes cannot encode arbitrarily large payloads
 * Only passphrase-based encryption is supported at the moment
 * Only the A4 paper size is supported at the moment
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         if path == PathBuf::from("-") {
             BufReader::new(Box::new(stdin().lock()))
         } else if path.is_file() {
+            let size = path.metadata()?.len();
+            if size >= 2048 {
+                warn!("File too large ({size:?} bytes). The maximum file size is about 1.9 KiB.");
+            }
             BufReader::new(Box::new(File::open(&path).unwrap()))
         } else {
             error!("File not found: {}", path.display());


### PR DESCRIPTION
Adds a warning if the input file is too large. Only a warning though as the maximum size is slightly non-deterministic (but always around ~1952 bytes or so).

Crude test script to iterate through incrementally large inputs:

```sh
#!/bin/bash

counter=976

echo "Start $counter ($((counter * 2)) bytes)"

export PAPERAGE_PASSPHRASE="snakeoil"

while openssl rand -hex $counter | cargo run -- -f -;
do
  counter=$((counter + 1))
  echo "Loop $counter ($((counter * 2)) bytes)"
done
```

Will close #11.

