### PR TITLE
Payload: Increase by compressing and using base64 encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "1056efa39f3f960845e69985c292022187b47bc3f83ddfc96edfc586007735a1"
 dependencies = [
  "age-core",
  "atty",
- "base64",
+ "base64 0.13.1",
  "bech32",
  "chacha20poly1305",
  "console",
@@ -62,7 +62,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d2e815ac879dc23c1139e720d21c6cd4d1276345c772587285d965a69b8f32"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "chacha20poly1305",
  "cookie-factory",
  "hkdf",
@@ -150,6 +150,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bech32"
@@ -1222,12 +1228,14 @@ dependencies = [
  "age",
  "assert_cmd",
  "assert_fs",
+ "base64 0.21.0",
  "clap",
  "clap-verbosity-flag",
  "clap_complete",
  "clap_mangen",
  "env_logger",
  "exitcode",
+ "flate2",
  "log",
  "path-absolutize",
  "predicates",
@@ -2186,7 +2194,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f472f6f5d41d3eaef059bc893dcd2382eefcdda3e04ebe0b2860c56b538e491e"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "data-url",
  "flate2",
  "float-cmp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ printpdf = { version = "0.5.3", features = ["svg"] }
 qrcode = "0.12.0"
 log = "0.4.17"
 env_logger = "0.10.0"
+flate2 = "1.0"
+base64 = "0.21.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ printpdf = { version = "0.5.3", features = ["svg"] }
 qrcode = "0.12.0"
 log = "0.4.17"
 env_logger = "0.10.0"
-flate2 = "1.0"
-base64 = "0.21.0"
+flate2 = { version="1.0", optional = true }
+base64 = { version="0.21.0", optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.0.8"
@@ -45,3 +45,6 @@ clap-verbosity-flag = "2.0.0"
 clap_mangen = { version = "0.2.8" }
 path-absolutize = "3.0.14"
 printpdf = { version = "0.5.3", features = ["svg"] }
+
+[features]
+compression = ["dep:flate2", "dep:base64"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Easy and secure paper backups of (smallish) secrets using the Age format ([age-e
 
 ## Limitations
 
-* The maximum input size is about 1.9 KiB as QR codes cannot encode arbitrarily large payloads
+* The maximum input size is about 1.9 KiB (127 KiB if using compression) as QR codes cannot encode arbitrarily large payloads
 * Only passphrase-based encryption is supported at the moment
 
 ## Threat models and use cases
@@ -131,6 +131,15 @@ cargo release 1.2.3
 ```
 
 ⚠️ Append `--execute` to the command to actually execute the release.
+
+### Compression
+
+You can optionally build the binary with `--features=compression` and pass the `--compress` flag during runtime to encrypt input data of up to 127 KiB.
+
+Example:
+```bash
+cargo run --features=compression -- in.txt --compress
+```
 
 ## License & Credits
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -103,28 +103,14 @@ impl Document {
 
         let current_layer = self.get_current_layer();
 
-        let mut font_size = 13.0;
-        let mut line_height = 15.0;
-
-        // Rudimentary text scaling to get the Ascii Armor text to fit
-        if pem.lines().count() > 42 {
-            font_size = 6.5;
-            line_height = 7.0;
-        } else if pem.lines().count() > 39 {
-            font_size = 7.0;
-            line_height = 8.0;
-        } else if pem.lines().count() > 27 {
-            font_size = 8.0;
-            line_height = 9.0;
-        } else if pem.lines().count() > 22 {
-            font_size = 10.0;
-            line_height = 12.0;
-        }
+        let font_size = 8.0;
+        let line_height = 8.0;
 
         current_layer.begin_text_section();
 
         current_layer.set_text_cursor(
-            self.page_size.dimensions().margin,
+            self.page_size.dimensions().margin
+                + Mm::from(Pt(font_size)) * 14.5,
             (self.page_size.dimensions().height / 2.0)
                 - Mm::from(Pt(font_size))
                 - self.page_size.dimensions().margin,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,6 +42,10 @@ pub struct Args {
     #[arg(short, long, default_value_t = false)]
     pub no_footer: bool,
 
+    /// Compress input with GZip and base64 encode it to output
+    #[arg(short, long, default_value_t = false)]
+    pub compress: bool,
+
     /// The path to the file to read. Defaults to standard input. Max. ~1.9KB.
     pub input: Option<PathBuf>,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,6 +38,10 @@ pub struct Args {
     #[clap(flatten)]
     pub verbose: Verbosity,
 
+    /// Disable drawing of footer
+    #[arg(short, long, default_value_t = false)]
+    pub no_footer: bool,
+
     /// The path to the file to read. Defaults to standard input. Max. ~1.9KB.
     pub input: Option<PathBuf>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,13 +67,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let reader: BufReader<Box<dyn Read>> = {
         if path == PathBuf::from("-") {
-            BufReader::new(Box::new(stdin().lock()))
+            BufReader::with_capacity(153600, Box::new(stdin().lock()))
         } else if path.is_file() {
             let size = path.metadata()?.len();
             if size >= 2048 {
                 warn!("File too large ({size:?} bytes). The maximum file size is about 1.9 KiB.");
             }
-            BufReader::new(Box::new(File::open(&path).unwrap()))
+            BufReader::with_capacity(153600, Box::new(File::open(&path).unwrap()))
         } else {
             error!("File not found: {}", path.display());
             std::process::exit(exitcode::NOINPUT);

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,8 +81,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let compressed_bytes = compress(reader);
-    let mut buf : Vec<u8> = Vec::new();
-    to_base64(compressed_bytes, &mut buf);
+    let base64_encoded = to_base64(compressed_bytes);
+    let buf : Vec<u8> = base64_encoded.as_bytes().to_vec();
     let mut compressed_reader = BufReader::new(Box::new(&buf[..]));
     let passphrase = get_passphrase()?;
 
@@ -162,19 +162,19 @@ fn get_passphrase() -> Result<Secret<String>, io::Error> {
 fn compress(mut reader: BufReader<Box<dyn Read>>) -> Vec<u8> {
     use std::io::prelude::*;
     use flate2::Compression;
-    use flate2::write::ZlibEncoder;
-	let mut e = ZlibEncoder::new(Vec::new(), Compression::default());
+    use flate2::write::GzEncoder;
+	let mut e = GzEncoder::new(Vec::new(), Compression::default());
 
     let _ = e.write_all(reader.fill_buf().unwrap());
     let compressed_bytes = e.finish();
 	compressed_bytes.unwrap()
 }
 
-fn to_base64(compressed_bytes: Vec<u8>, buf: &mut Vec<u8>) {
+fn to_base64(compressed_bytes: Vec<u8>) -> String{
     use base64::{Engine as _, engine::general_purpose};
-    buf.resize(compressed_bytes.len() * 4 / 3 + 4, 0);
-    let bytes_written = general_purpose::STANDARD.encode_slice(compressed_bytes, buf).unwrap();
-    buf.truncate(bytes_written);
+    let output = general_purpose::STANDARD.encode(compressed_bytes);
+    println!("Output: {output}");
+    output
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     pdf.insert_pem_text(encrypted);
 
-    pdf.insert_footer();
+    if !args.no_footer {
+        pdf.insert_footer();
+    }
 
     if output == PathBuf::from("-") {
         debug!("Writing to STDOUT");

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,7 @@ fn get_passphrase() -> Result<Secret<String>, io::Error> {
     }
 }
 
+#[cfg(feature = "compression")]
 fn compress(mut reader: BufReader<Box<dyn Read>>) -> Vec<u8> {
     use std::io::prelude::*;
     use flate2::Compression;
@@ -177,10 +178,21 @@ fn compress(mut reader: BufReader<Box<dyn Read>>) -> Vec<u8> {
 	compressed_bytes.unwrap()
 }
 
+#[cfg(feature = "compression")]
 fn to_base64(compressed_bytes: Vec<u8>) -> String{
     use base64::{Engine as _, engine::general_purpose};
     let output = general_purpose::STANDARD.encode(compressed_bytes);
     output
+}
+
+#[cfg(not(feature = "compression"))]
+fn compress(_: BufReader<Box<dyn Read>>) -> Vec<u8> {
+    panic!("Compression-related function called but binary not built with --feature=compression");
+}
+
+#[cfg(not(feature = "compression"))]
+fn to_base64(_: Vec<u8>) -> String{
+    panic!("Compression-related function called but binary not built with --feature=compression");
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Hi,

Nice work! I was wondering if one could increase the payload of the generated QR. Based on [this](https://stackoverflow.com/a/75572388/2394327), one could theoretically encode about 173kB of text using gzip and base64 encoding that runs before the QR stage.

This PR adds support for generating output of 127kB of data using the `--compress` flag.