### PR TITLE
Add option to center all text, and display encryption time by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 test-output.json
 /visual-snapshots
 *.profraw
+.idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +325,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
 
 [[package]]
+name = "chrono"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "time 0.1.45",
+ "wasm-bindgen",
+ "windows-targets 0.48.1",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +455,12 @@ name = "cookie-factory"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396de984970346b0d9e93d1415082923c679e5ae5c3ee3dcbd104f5610af126b"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
@@ -957,6 +993,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ignore"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,7 +1228,7 @@ dependencies = [
  "linked-hash-map",
  "log",
  "pom",
- "time",
+ "time 0.2.27",
  "weezl",
 ]
 
@@ -1313,6 +1372,7 @@ dependencies = [
  "age",
  "assert_cmd",
  "assert_fs",
+ "chrono",
  "clap",
  "clap-verbosity-flag",
  "clap_complete",
@@ -1513,7 +1573,7 @@ dependencies = [
  "owned_ttf_parser",
  "pdf-writer",
  "svg2pdf",
- "time",
+ "time 0.2.27",
  "usvg",
 ]
 
@@ -2142,6 +2202,17 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
@@ -2388,6 +2459,12 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -2493,6 +2570,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.1",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ printpdf = { version = "0.5.3", features = ["svg"] }
 qrcode = "0.12.0"
 log = "0.4"
 env_logger = "0.10"
+chrono = "0.4.28"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,6 +22,10 @@ pub struct Args {
     #[arg(short = 's', long, default_value_t = PageSize::A4)]
     pub page_size: PageSize,
 
+    /// Center all text
+    #[arg(short, long, default_value_t = false)]
+    pub center: bool,
+
     /// Overwrite the output file if it already exists
     #[arg(short, long, default_value_t = false)]
     pub force: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,6 +26,10 @@ pub struct Args {
     #[arg(short, long, default_value_t = false)]
     pub center: bool,
 
+    /// Display passphrase field instead of time
+    #[arg(short = 'P', long, default_value_t = false)]
+    pub passphrase_field: bool,
+
     /// Overwrite the output file if it already exists
     #[arg(short, long, default_value_t = false)]
     pub force: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    pdf.insert_passphrase();
+    pdf.insert_time_or_passphrase(args.passphrase_field, args.center);
 
     pdf.draw_line(
         vec![

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         pdf.draw_grid();
     }
 
-    pdf.insert_title_text(args.title);
+    pdf.insert_title_text(args.title, args.center);
 
     match pdf.insert_qr_code(encrypted.clone()) {
         Ok(()) => (),
@@ -123,9 +123,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     );
 
-    pdf.insert_pem_text(encrypted);
+    pdf.insert_pem_text(encrypted, args.center);
 
-    pdf.insert_footer();
+    pdf.insert_footer(args.center);
 
     if output == PathBuf::from("-") {
         debug!("Writing to STDOUT");


### PR DESCRIPTION
I learned Rust from scratch and implemented the features I mentioned in #88. 😄

There's a breaking change I made, to replace the passphrase field (Passphrase: _____) with encryption time (Encrypted at XXXX) by default. The passphrase field can be restored with `-P` option.

The reason I made this decision is that I think the vast majority of people don't write their passphrase directly on paper, resulting in wasted space being taken up. If you have any comments about this, please communicate with me.

Options added:
- `-c, --center` - Center all text
- `-P, --passphrase-field` - Display passphrase field instead of time

Closes #88 