### PR TITLE
Decrease test_stdout's expected size: 400 -> 200 KiB

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -51,7 +51,7 @@ fn test_stdout() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut cmd = Command::cargo_bin("paper-age")?;
 
-    let output_size = 400 * 1024; // 400 KiB
+    let output_size = 200 * 1024; // 200 KiB
     let len_predicate_fn = predicate::function(|x: &[u8]| x.len() > output_size);
 
     cmd.arg("--output")


### PR DESCRIPTION
Motivation: Make `cargo test --release` pass. This is useful for NixOS packaging, because NixOS tests against a release binary.

Currently the 'test_stdout' fails with `--release`, since the test expects the PDF to be > 400KiB, but the release PDF is 337 KiB.

Here we see the debug binary outputting 516 KB:

```
$ echo STDOUT | PAPERAGE_PASSPHRASE=secret cargo run  -- -o - | wc --bytes
    Finished dev [unoptimized + debuginfo] target(s) in 0.27s
     Running `target/debug/paper-age -o -`
515997
```

Here we see the release binary outputting 337KB:

```
$ echo STDOUT | PAPERAGE_PASSPHRASE=secret cargo run --release  -- -o - | wc --bytes
    Finished release [optimized] target(s) in 0.41s
     Running `target/release/paper-age -o -`
336980
```

So let's decrease the test limit. I guess the value of the test is mostly in checking that the PDF isn't less than < 10KB. The PDFs are visually indistinguishable from my eye.