### PR TITLE
Run macOS tests on `macos-14`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
+        os: [ "ubuntu-latest", "macos-14", "windows-latest" ]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This should launch an M1 runner:

https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/